### PR TITLE
close db after dropping collection

### DIFF
--- a/test_books_crud.py
+++ b/test_books_crud.py
@@ -16,8 +16,8 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event():
-    app.mongodb_client.close()
     app.database.drop_collection("books")
+    app.mongodb_client.close()
 
 def test_create_book():
     with TestClient(app) as client:


### PR DESCRIPTION
The shutdown event handler should close the mongodb connection after dropping the collection.   The problem is more apparent with Pymongo4.  With Pymongo4 the unit test fails with "Cannot use MongoClient after close" error.